### PR TITLE
Fix entity references in java reader

### DIFF
--- a/CGMES_2.4.15_27JAN2020/src/main/java/cim4j/utils/RdfWriter.java
+++ b/CGMES_2.4.15_27JAN2020/src/main/java/cim4j/utils/RdfWriter.java
@@ -381,7 +381,7 @@ public class RdfWriter {
         if (profiles != null && profiles.contains(classProfile)) {
             return classProfile;
         }
-        if (!profiles.isEmpty()) {
+        if (profiles != null && !profiles.isEmpty()) {
             var list = new ArrayList<CGMESProfile>(profiles);
             Collections.sort(list);
             return list.get(0);

--- a/CGMES_2.4.15_27JAN2020/src/test/java/cim4j/utils/RdfReaderTest.java
+++ b/CGMES_2.4.15_27JAN2020/src/test/java/cim4j/utils/RdfReaderTest.java
@@ -506,6 +506,24 @@ class RdfReaderTest {
         assertNull(topologicalIsland.getAttribute("name"));
     }
 
+    @Test
+    @Order(360)
+    void testRead023() {
+        var cimData = RdfReader.read(List.of(getPath("rdf/test023.xml")));
+        assertEquals(1, cimData.size());
+
+        assertTrue(cimData.containsKey("BaseVoltage.20"));
+
+        var baseVoltage = cimData.get("BaseVoltage.20");
+        assertNotNull(baseVoltage);
+
+        var attributeNames = baseVoltage.getAttributeNames();
+        assertTrue(attributeNames.contains("description"));
+        assertTrue(attributeNames.contains("name"));
+        assertEquals("<&> <&> <&>", baseVoltage.getAttribute("description").toString(false));
+        assertEquals("unknown entity reference: &nbsp;", baseVoltage.getAttribute("name").toString(false));
+    }
+
     private String getPath(String aResource) {
         var url = getClass().getClassLoader().getResource(aResource);
         assertNotNull(url);

--- a/CGMES_2.4.15_27JAN2020/src/test/java/cim4j/utils/RdfWriterTest.java
+++ b/CGMES_2.4.15_27JAN2020/src/test/java/cim4j/utils/RdfWriterTest.java
@@ -756,6 +756,36 @@ class RdfWriterTest {
     }
 
     @Test
+    @Order(460)
+    void testWrite023() {
+        var cimData = RdfReader.read(List.of(getPath("rdf/test023.xml")));
+        assertEquals(1, cimData.size());
+
+        assertTrue(cimData.containsKey("BaseVoltage.20"));
+
+        var rdfWriter = new RdfWriter();
+        rdfWriter.addCimData(cimData);
+        rdfWriter.write("target/test.xml");
+
+        var stringWriter = new StringWriter();
+        rdfWriter.write(stringWriter);
+        String result = stringWriter.toString();
+
+        var lines = result.lines().toArray();
+        assertEquals(7, lines.length);
+        assertEquals(XML_HEADER, lines[0]);
+        assertEquals(RDF_HEADER, lines[1]);
+        assertEquals("  <cim:BaseVoltage rdf:ID=\"BaseVoltage.20\">", lines[2]);
+        assertEquals(
+                "    <cim:IdentifiedObject.description>&lt;&amp;&gt; &lt;&amp;&gt; &lt;&amp;&gt;</cim:IdentifiedObject.description>",
+                lines[3]);
+        assertEquals("    <cim:IdentifiedObject.name>unknown entity reference: &amp;nbsp;</cim:IdentifiedObject.name>",
+                lines[4]);
+        assertEquals("  </cim:BaseVoltage>", lines[5]);
+        assertEquals("</rdf:RDF>", lines[6]);
+    }
+
+    @Test
     @Order(900)
     void testWriteEmpty() {
         var rdfWriter = new RdfWriter();

--- a/CGMES_2.4.15_27JAN2020/src/test/java/cim4j/utils/RdfWriterTest.java
+++ b/CGMES_2.4.15_27JAN2020/src/test/java/cim4j/utils/RdfWriterTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringWriter;
@@ -495,26 +496,43 @@ class RdfWriterTest {
         assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.EQ));
         assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.TP));
 
-        // All profiles are matching because of the attributes inherited from
+        // Many profiles are matching because of the attributes inherited from
         // IdentifiedObject (e.g. name).
-        for (CGMESProfile profile : CGMESProfile.values()) {
-            assertTrue(RdfWriter.isClassMatchingProfile(cimObj, profile));
-        }
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.DL));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.DY));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.GL));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.SSH));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.SV));
 
         cimObj = new VoltageLevel();
-        for (CGMESProfile profile : CGMESProfile.values()) {
-            assertTrue(RdfWriter.isClassMatchingProfile(cimObj, profile));
-        }
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.EQ));
+
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.DL));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.DY));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.GL));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.SSH));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.SV));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.TP));
 
         cimObj = new TopologicalNode();
-        for (CGMESProfile profile : CGMESProfile.values()) {
-            assertTrue(RdfWriter.isClassMatchingProfile(cimObj, profile));
-        }
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.SV));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.TP));
+
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.EQ));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.DL));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.DY));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.GL));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.SSH));
 
         cimObj = new TopologicalIsland();
-        for (CGMESProfile profile : CGMESProfile.values()) {
-            assertTrue(RdfWriter.isClassMatchingProfile(cimObj, profile));
-        }
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.SV));
+
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.EQ));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.DL));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.DY));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.GL));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.SSH));
+        assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.TP));
 
         cimObj = new SvVoltage();
         assertTrue(RdfWriter.isClassMatchingProfile(cimObj, CGMESProfile.SV));
@@ -524,9 +542,9 @@ class RdfWriterTest {
         // SvVoltage does not inherit from IdentifiedObject
         for (CGMESProfile profile : CGMESProfile.values()) {
             if (profile == CGMESProfile.SV) {
-                assertTrue(RdfWriter.isClassMatchingProfile(cimObj, profile));
+                assertTrue(RdfWriter.isClassMatchingProfile(cimObj, profile), profile.toString());
             } else {
-                assertFalse(RdfWriter.isClassMatchingProfile(cimObj, profile));
+                assertFalse(RdfWriter.isClassMatchingProfile(cimObj, profile), profile.toString());
             }
         }
     }
@@ -594,6 +612,8 @@ class RdfWriterTest {
         assertEquals(CGMESProfile.SV, RdfWriter.getAttributeProfile(cimObj, "TopologicalNodes", profile));
         assertEquals(CGMESProfile.SV, RdfWriter.getAttributeProfile(cimObj, "name", profile));
         assertEquals(CGMESProfile.EQ, RdfWriter.getAttributeProfile(cimObj, "description", profile));
+
+        assertNull(RdfWriter.getAttributeProfile(cimObj, "dummy", profile));
     }
 
     @Test

--- a/CGMES_2.4.15_27JAN2020/src/test/resources/rdf/test023.xml
+++ b/CGMES_2.4.15_27JAN2020/src/test/resources/rdf/test023.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#">
+  <cim:BaseVoltage rdf:ID="BaseVoltage.20">
+    <cim:IdentifiedObject.description>&lt;&amp;&gt; &#60;&#38;&#62; &#x3C;&#x26;&#x3E;</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>unknown entity reference: &nbsp;</cim:IdentifiedObject.name>
+  </cim:BaseVoltage>
+</rdf:RDF>


### PR DESCRIPTION
- Fix reading text with entity references in java reader
  - If an XML text value contains entity references the text is splitted into several events and has to be concatenated to get the full text value.
  - Some entity references are replaced, like `&lt;` ->`<`, `&gt;` ->`>` etc. and provided as CHARACTERS event.
  - Other (unknown) entitity references are provided as ENTITY_REFERENCE event without `&` and `;`.
- Add unit test for reading text with entity references
- Fix null pointer exception in RdfWriter.getAttributeProfile()
